### PR TITLE
Refactor WMI COM usage in diagnostics

### DIFF
--- a/src-tauri/src/native_diagnostics.rs
+++ b/src-tauri/src/native_diagnostics.rs
@@ -10,22 +10,23 @@ use winreg::enums::*;
 use winreg::RegKey;
 use scraper::{Html, Selector};
 
-pub struct NativeDiagnostics {
-    com_lib: COMLibrary,
-}
+pub struct NativeDiagnostics;
 
 impl NativeDiagnostics {
     pub fn new() -> Result<Self> {
+        Ok(Self {})
+    }
+
+    fn create_wmi_connection(&self, namespace: Option<&str>) -> Result<WMIConnection> {
         let com_lib = COMLibrary::new()?;
-        Ok(Self { com_lib })
+        match namespace {
+            Some(ns) => WMIConnection::with_namespace_path(ns, com_lib.into()),
+            None => WMIConnection::new(com_lib.into()),
+        }
     }
 
     pub fn run_wmi_query(&self, class_name: &str, namespace: Option<&str>) -> Result<Value> {
-        let wmi_con = if let Some(ns) = namespace {
-            WMIConnection::with_namespace_path(ns, self.com_lib.into())?
-        } else {
-            WMIConnection::new(self.com_lib.into())?
-        };
+        let wmi_con = self.create_wmi_connection(namespace)?;
         let results: Vec<HashMap<String, wmi::Variant>> = wmi_con.raw_query(&format!("SELECT * FROM {}", class_name))?;
         
         let mut json_results = Vec::new();
@@ -57,7 +58,7 @@ impl NativeDiagnostics {
     }
 
     pub fn get_native_disk_space(&self) -> Result<Value> {
-        let wmi_con = WMIConnection::new(self.com_lib.into())?;
+        let wmi_con = self.create_wmi_connection(None)?;
         let results: Vec<HashMap<String, wmi::Variant>> = wmi_con.raw_query("SELECT * FROM Win32_LogicalDisk WHERE DriveType=3")?;
         
         let mut drives = Vec::new();
@@ -76,7 +77,7 @@ impl NativeDiagnostics {
     }
 
     pub fn get_native_network_adapters(&self) -> Result<Value> {
-        let wmi_con = WMIConnection::new(self.com_lib.into())?;
+        let wmi_con = self.create_wmi_connection(None)?;
         let config_results: Vec<HashMap<String, wmi::Variant>> = wmi_con.raw_query("SELECT * FROM Win32_NetworkAdapterConfiguration WHERE IPEnabled=TRUE")?;
         let adapter_results: Vec<HashMap<String, wmi::Variant>> = wmi_con.raw_query("SELECT * FROM Win32_NetworkAdapter")?;
         
@@ -144,7 +145,7 @@ impl NativeDiagnostics {
 
     pub fn get_native_system_info(&self) -> Result<Value> {
         // Get OS info from WMI
-        let wmi_con = WMIConnection::new(self.com_lib.into())?;
+        let wmi_con = self.create_wmi_connection(None)?;
         let os_results: Vec<HashMap<String, wmi::Variant>> = wmi_con.raw_query("SELECT * FROM Win32_OperatingSystem")?;
         let comp_results: Vec<HashMap<String, wmi::Variant>> = wmi_con.raw_query("SELECT * FROM Win32_ComputerSystem")?;
         
@@ -235,7 +236,7 @@ impl NativeDiagnostics {
     }
 
     pub fn get_drivers(&self) -> Result<Value> {
-        let wmi_con = WMIConnection::new(self.com_lib.into())?;
+        let wmi_con = self.create_wmi_connection(None)?;
         let mut drivers = Vec::new();
         
         // Get PnP signed drivers (main source on modern Windows)
@@ -284,7 +285,7 @@ impl NativeDiagnostics {
     }
 
     pub fn get_event_logs(&self) -> Result<Value> {
-        let wmi_con = WMIConnection::new(self.com_lib.into())?;
+        let wmi_con = self.create_wmi_connection(None)?;
         
         let mut all_events = Vec::new();
         
@@ -375,7 +376,7 @@ impl NativeDiagnostics {
     }
     
     fn get_directx_info_via_wmi(&self) -> Result<Value> {
-        let wmi_con = WMIConnection::new(self.com_lib.into())?;
+        let wmi_con = self.create_wmi_connection(None)?;
         let mut info = json!({
             "source": "WMI",
             "description": "DirectX information gathered from Windows Management Instrumentation"
@@ -466,7 +467,7 @@ impl NativeDiagnostics {
             }
             
             // Also get disk info from WMI
-            let wmi_con = WMIConnection::new(self.com_lib.into())?;
+            let wmi_con = self.create_wmi_connection(None)?;
             if let Ok(results) = wmi_con.raw_query::<HashMap<String, wmi::Variant>>(
                 "SELECT * FROM Win32_DiskDrive"
             ) {
@@ -488,7 +489,7 @@ impl NativeDiagnostics {
             // Check if it's an elevation error
             if error_str.contains("requires elevated") || error_str.contains("Access is denied") {
                 // If we can't run chkdsk, at least get disk info
-                let wmi_con = WMIConnection::new(self.com_lib.into())?;
+                let wmi_con = self.create_wmi_connection(None)?;
                 let results: Vec<HashMap<String, wmi::Variant>> = wmi_con.raw_query(
                     "SELECT * FROM Win32_DiskDrive"
                 )?;
@@ -620,7 +621,7 @@ impl NativeDiagnostics {
 
     pub fn run_dsregcmd(&self) -> Result<Value> {
         // Check domain join status via WMI
-        let wmi_con = WMIConnection::new(self.com_lib.into())?;
+        let wmi_con = self.create_wmi_connection(None)?;
         
         let cs_results: Vec<HashMap<String, wmi::Variant>> = wmi_con.raw_query(
             "SELECT Domain, DomainRole, PartOfDomain FROM Win32_ComputerSystem"
@@ -640,7 +641,7 @@ impl NativeDiagnostics {
     }
 
     pub fn get_disk_fragmentation(&self) -> Result<Value> {
-        let wmi_con = WMIConnection::new(self.com_lib.into())?;
+        let wmi_con = self.create_wmi_connection(None)?;
         let disks: Vec<HashMap<String, wmi::Variant>> = wmi_con.raw_query("SELECT Name FROM Win32_LogicalDisk WHERE DriveType=3")?;
         
         let mut fragmentation_results = Vec::new();
@@ -695,7 +696,7 @@ impl NativeDiagnostics {
     }
 
     pub fn get_native_services(&self) -> Result<Value> {
-        let wmi_con = WMIConnection::new(self.com_lib.into())?;
+        let wmi_con = self.create_wmi_connection(None)?;
         let results: Vec<HashMap<String, wmi::Variant>> = wmi_con.raw_query(
             "SELECT Name, DisplayName, State, StartMode, PathName FROM Win32_Service"
         )?;
@@ -1028,7 +1029,7 @@ impl NativeDiagnostics {
     }
 
     pub fn get_performance_data(&self) -> Result<Value> {
-        let wmi_con = WMIConnection::new(self.com_lib.into())?;
+        let wmi_con = self.create_wmi_connection(None)?;
         let mut perf_data = json!({});
         
         // Get CPU performance data
@@ -1098,7 +1099,7 @@ impl NativeDiagnostics {
     }
 
     pub fn get_windows_update_history(&self) -> Result<Value> {
-        let wmi_con = WMIConnection::new(self.com_lib.into())?;
+        let wmi_con = self.create_wmi_connection(None)?;
         let mut update_info = json!({});
         
         // Get installed hotfixes


### PR DESCRIPTION
## Summary
- avoid storing a shared COMLibrary in NativeDiagnostics by generating one on demand
- update all WMI entry points to request connections through the new helper to prevent moves out of immutable references

## Testing
- cargo +1.88.0 check --manifest-path src-tauri/Cargo.toml *(fails: missing glib-2.0 development files in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cce73fb8b483219daebe4845d17215